### PR TITLE
Make expanded list as default behavior

### DIFF
--- a/lib/components/Form.js
+++ b/lib/components/Form.js
@@ -114,7 +114,7 @@ var Form = function (_Component) {
     };
 
     _this.state = _this.getStateFromProps(props);
-    _this.state.expandAll = false;
+    _this.state.expandAll = true;
     return _this;
   }
 

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -28,7 +28,7 @@ export default class Form extends Component {
     super(props);
 
     this.state = this.getStateFromProps(props);
-    this.state.expandAll = false;
+    this.state.expandAll = true;
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
### Reasons for making this change

Expand body param in API Explorer by default
Link: https://github.com/apimatic/apimatic-dx-portal/issues/286

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
