### PR TITLE
Remove duplication of object name in oneof and discriminator field

### DIFF
--- a/lib/components/fields/ArrayField.js
+++ b/lib/components/fields/ArrayField.js
@@ -40,6 +40,8 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
 function ArrayFieldTitle(_ref) {
@@ -253,6 +255,11 @@ function DefaultFixedArrayFieldTemplate(props) {
 }
 
 function DefaultNormalArrayFieldTemplate(props) {
+  var _classNames;
+
+  var fromDiscriminator = props.fromDiscriminator;
+
+  var headerClasses = (0, _utils.classNames)((_classNames = {}, _defineProperty(_classNames, (0, _utils.prefixClass)("object-header"), true), _defineProperty(_classNames, "position-unset", fromDiscriminator), _classNames));
   var title = props.uiSchema["ui:title"] || props.schema.title || props.itemsSchema.title || props.title;
 
   var dataType = props.schema.dataTypeDisplayText;
@@ -263,11 +270,11 @@ function DefaultNormalArrayFieldTemplate(props) {
     { className: (0, _utils.prefixClass)(props.className) },
     _react2.default.createElement(
       "div",
-      { className: (0, _utils.prefixClass)("object-header") },
+      { className: headerClasses },
       _react2.default.createElement(
         "div",
         { className: (0, _utils.prefixClass)("header-left hand"), onClick: props.toggleCollapse },
-        _react2.default.createElement(ArrayFieldTitle, {
+        props.fromDiscriminator ? null : _react2.default.createElement(ArrayFieldTitle, {
           key: "array-field-title-" + props.idSchema.$id,
           TitleField: props.TitleField,
           idSchema: props.idSchema,
@@ -285,7 +292,7 @@ function DefaultNormalArrayFieldTemplate(props) {
         {
           tabIndex: "-1",
           onClick: props.toggleCollapse,
-          className: (0, _utils.prefixClass)("btn toggle-button " + (title ? "" : "anyof")) },
+          className: (0, _utils.prefixClass)("btn toggle-button") },
         props.collapse ? _react2.default.createElement(_Icons.ChevronIcon, { width: 14, rotate: -90 }) : _react2.default.createElement(_Icons.ChevronIcon, { width: 14 }),
         " "
       ),

--- a/lib/components/fields/DiscriminatorField.js
+++ b/lib/components/fields/DiscriminatorField.js
@@ -375,7 +375,8 @@ var DiscriminatorField = function (_React$Component) {
           nullify: checked,
           required: !optional,
           onNullifyChange: this.toggleCheckbox,
-          fromDiscriminator: fromDiscriminator }),
+          fromDiscriminator: fromDiscriminator
+        }),
         !optional || optional && checked && !disabled ? _react2.default.createElement(
           "fieldset",
           {

--- a/lib/components/fields/MapField.js
+++ b/lib/components/fields/MapField.js
@@ -26,13 +26,13 @@ var _DataType2 = _interopRequireDefault(_DataType);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
@@ -164,6 +164,11 @@ function DefaultMapItem(props) {
 }
 
 function DefaultNormalMapFieldTemplate(props) {
+  var _classNames;
+
+  var fromDiscriminator = props.fromDiscriminator;
+
+  var headerClasses = (0, _utils.classNames)((_classNames = {}, _defineProperty(_classNames, (0, _utils.prefixClass)("object-header"), true), _defineProperty(_classNames, "position-unset", fromDiscriminator), _classNames));
   var dataType = props.schema.dataTypeDisplayText;
   var markdown = props.schema.dataTypeMarkdown;
 
@@ -172,7 +177,7 @@ function DefaultNormalMapFieldTemplate(props) {
     { className: (0, _utils.prefixClass)(props.className) },
     _react2.default.createElement(
       "div",
-      { className: (0, _utils.prefixClass)("object-header") },
+      { className: headerClasses },
       _react2.default.createElement(
         "div",
         {
@@ -195,7 +200,7 @@ function DefaultNormalMapFieldTemplate(props) {
         {
           tabIndex: "-1",
           onClick: props.toggleGroupCollapse,
-          className: (0, _utils.prefixClass)("btn toggle-button " + (props.title ? "" : "anyof")) },
+          className: (0, _utils.prefixClass)("btn toggle-button") },
         props.collapse ? _react2.default.createElement(_Icons.ChevronIcon, { width: 14, rotate: -90 }) : _react2.default.createElement(_Icons.ChevronIcon, { width: 14 })
       )
     ),

--- a/lib/components/fields/ObjectField.js
+++ b/lib/components/fields/ObjectField.js
@@ -611,8 +611,9 @@ var ObjectField = function (_Component) {
               readonly: templateProps.readonly,
               disableFormJsonEdit: templateProps.disableFormJsonEdit,
               typeCombinatorTypes: typeCombinatorTypes,
-              discriminatorObj: discriminatorObj,
-              directCircularRef: templateProps.schema.dataTypeLink === templateProps.schema.properties[name].dataTypeLink
+              discriminatorObj: discriminatorObj
+              // flag for direct circular reference in the objects
+              , directCircularRef: templateProps.schema.dataTypeLink === templateProps.schema.properties[name].dataTypeLink
             }),
             name: name,
             readonly: templateProps.readonly,

--- a/lib/components/fields/ObjectField.js
+++ b/lib/components/fields/ObjectField.js
@@ -38,13 +38,13 @@ var _Icons = require("../Icons");
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
@@ -163,14 +163,18 @@ function DefaultOnlyProperties(props) {
 }
 
 function DefaultObjectFieldTemplate(props) {
+  var _classNames;
+
   var TitleField = props.TitleField,
       DescriptionField = props.DescriptionField,
       nullify = props.nullify,
       onNullifyChange = props.onNullifyChange,
       disabled = props.disabled,
       collapse = props.collapse,
-      toggleCollapse = props.toggleCollapse;
+      toggleCollapse = props.toggleCollapse,
+      fromDiscriminator = props.fromDiscriminator;
 
+  var headerClasses = (0, _utils.classNames)((_classNames = {}, _defineProperty(_classNames, (0, _utils.prefixClass)("object-header"), true), _defineProperty(_classNames, "position-unset", fromDiscriminator), _classNames));
 
   var canEditJson = nullify && !props.disableFormJsonEdit && !props.uiSchema.disableFieldJsonEdit;
 
@@ -187,7 +191,7 @@ function DefaultObjectFieldTemplate(props) {
       id: props.idSchema.$id + "__object" },
     _react2.default.createElement(
       "div",
-      { className: (0, _utils.prefixClass)("object-header") },
+      { className: headerClasses },
       _react2.default.createElement(
         "div",
         { className: (0, _utils.prefixClass)("header-left hand"), onClick: toggleCollapse },

--- a/lib/components/fields/SchemaField.js
+++ b/lib/components/fields/SchemaField.js
@@ -324,6 +324,7 @@ function SchemaFieldRender(props) {
 
   var isDiscriminator = discriminatorProperty && discriminatorProperty === name;
 
+  // If direct circular reference, we will not fetch further schema through references
   var schema = directCircularRef ? props.schema : (0, _utils.retrieveSchema)(props.schema, formData, dxInterface);
 
   if (schema.allOf && !schema.typeCombinatorTypes) {
@@ -422,7 +423,7 @@ function SchemaFieldRender(props) {
     discriminatorObj: discriminatorObj
   }));
 
-  return (0, _utils.isOneOfSchema)(schema) || !(0, _utils.isOneOfSchema)(schema) && schema.typeCombinatorTypes ? field : _react2.default.createElement(
+  return (0, _utils.isOneOfSchema)(schema) || !(0, _utils.isOneOfSchema)(schema) && schema.typeCombinatorTypes && schema.type !== "array" ? field : _react2.default.createElement(
     FieldTemplate,
     fieldProps,
     field

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -16,6 +16,7 @@ import {
   toIdSchema,
   getDefaultRegistry,
   prefixClass as pfx,
+  classNames,
 } from "../../utils";
 import { ArrowUpIcon, DeleteIcon, ArrowDownIcon, ChevronIcon } from "../Icons";
 
@@ -204,6 +205,11 @@ function DefaultFixedArrayFieldTemplate(props) {
 }
 
 function DefaultNormalArrayFieldTemplate(props) {
+  const { fromDiscriminator } = props;
+  const headerClasses = classNames({
+    [pfx("object-header")]: true,
+    "position-unset": fromDiscriminator,
+  });
   const title =
     props.uiSchema["ui:title"] ||
     props.schema.title ||
@@ -215,25 +221,27 @@ function DefaultNormalArrayFieldTemplate(props) {
 
   return (
     <fieldset className={pfx(props.className)}>
-      <div className={pfx("object-header")}>
+      <div className={headerClasses}>
         <div className={pfx("header-left hand")} onClick={props.toggleCollapse}>
-          <ArrayFieldTitle
-            key={`array-field-title-${props.idSchema.$id}`}
-            TitleField={props.TitleField}
-            idSchema={props.idSchema}
-            title={title}
-            required={props.required}
-            nullify={props.nullify}
-            onNullifyChange={props.onNullifyChange}
-            disabled={props.disabled}
-            fromDiscriminator={props.fromDiscriminator}
-            // onClick={props.toggleCollapse}
-          />
+          {props.fromDiscriminator ? null : (
+            <ArrayFieldTitle
+              key={`array-field-title-${props.idSchema.$id}`}
+              TitleField={props.TitleField}
+              idSchema={props.idSchema}
+              title={title}
+              required={props.required}
+              nullify={props.nullify}
+              onNullifyChange={props.onNullifyChange}
+              disabled={props.disabled}
+              fromDiscriminator={props.fromDiscriminator}
+              // onClick={props.toggleCollapse}
+            />
+          )}
         </div>
         <IconBtn
           tabIndex="-1"
           onClick={props.toggleCollapse}
-          className={pfx(`btn toggle-button ${title ? "" : "anyof"}`)}>
+          className={pfx(`btn toggle-button`)}>
           {props.collapse ? (
             <ChevronIcon width={14} rotate={-90} />
           ) : (

--- a/src/components/fields/MapField.js
+++ b/src/components/fields/MapField.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { prefixClass as pfx } from "../../utils";
+import { classNames, prefixClass as pfx } from "../../utils";
 
 import {
   getDefaultFormState,
@@ -129,12 +129,17 @@ function DefaultMapItem(props) {
 }
 
 function DefaultNormalMapFieldTemplate(props) {
+  const { fromDiscriminator } = props;
+  const headerClasses = classNames({
+    [pfx("object-header")]: true,
+    "position-unset": fromDiscriminator,
+  });
   const dataType = props.schema.dataTypeDisplayText;
   const markdown = props.schema.dataTypeMarkdown;
 
   return (
     <fieldset className={pfx(props.className)}>
-      <div className={pfx("object-header")}>
+      <div className={headerClasses}>
         <div
           className={pfx("header-left hand")}
           onClick={props.toggleGroupCollapse}>
@@ -154,7 +159,7 @@ function DefaultNormalMapFieldTemplate(props) {
         <IconBtn
           tabIndex="-1"
           onClick={props.toggleGroupCollapse}
-          className={pfx(`btn toggle-button ${props.title ? "" : "anyof"}`)}>
+          className={pfx(`btn toggle-button`)}>
           {props.collapse ? (
             <ChevronIcon width={14} rotate={-90} />
           ) : (

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import MapField from "./MapField";
-import { prefixClass as pfx } from "../../utils";
+import { classNames, prefixClass as pfx } from "../../utils";
 import { toErrorList } from "../../validate";
 import CodeMirror from "react-codemirror2";
 import DataType from "../fields/DataType";
@@ -125,7 +125,12 @@ function DefaultObjectFieldTemplate(props) {
     disabled,
     collapse,
     toggleCollapse,
+    fromDiscriminator,
   } = props;
+  const headerClasses = classNames({
+    [pfx("object-header")]: true,
+    "position-unset": fromDiscriminator,
+  });
 
   let canEditJson =
     nullify &&
@@ -146,7 +151,7 @@ function DefaultObjectFieldTemplate(props) {
     <fieldset
       className={pfx((props.isEven ? "even" : "odd") + ` depth_${props.depth}`)}
       id={`${props.idSchema.$id}__object`}>
-      <div className={pfx("object-header")}>
+      <div className={headerClasses}>
         <div className={pfx("header-left hand")} onClick={toggleCollapse}>
           {title && (
             <TitleField

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -405,7 +405,9 @@ function SchemaFieldRender(props) {
   );
 
   return isOneOfSchema(schema) ||
-    (!isOneOfSchema(schema) && schema.typeCombinatorTypes) ? (
+    (!isOneOfSchema(schema) &&
+      schema.typeCombinatorTypes &&
+      schema.type !== "array") ? (
     field
   ) : (
     <FieldTemplate {...fieldProps}>{field}</FieldTemplate>


### PR DESCRIPTION
### Reasons for making this change
Fix is related oneof/anyof and discriminator. There is the duplication of object name in oneof/anyof and discriminator.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [x] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
