### PR TITLE
Arrow button use to move parameter field section vertically up and down not working

### DIFF
--- a/lib/components/Form.js
+++ b/lib/components/Form.js
@@ -160,9 +160,12 @@ var Form = function (_Component) {
           errors = _ref.errors,
           errorSchema = _ref.errorSchema;
 
+      var idSchema = (0, _utils.toIdSchema)(schema, uiSchema["ui:rootFieldId"], formData, dxInterface);
+
       return {
         schema: schema,
         uiSchema: uiSchema,
+        idSchema: idSchema,
         formData: formData,
         edit: edit,
         errors: errors,
@@ -273,8 +276,7 @@ var Form = function (_Component) {
           encType: enctype,
           acceptCharset: acceptcharset,
           noValidate: noHtml5Validate,
-          onSubmit: this.onSubmit
-        },
+          onSubmit: this.onSubmit },
         _react2.default.createElement(
           _context.ContextProvider,
           { value: dxInterface },

--- a/lib/components/Icons.js
+++ b/lib/components/Icons.js
@@ -86,6 +86,12 @@ var ArrowUpIcon = exports.ArrowUpIcon = function ArrowUpIcon(_ref5) {
   var width = _ref5.width,
       color = _ref5.color,
       rotate = _ref5.rotate;
+
+  var headerClass = (0, _utils.classNames)({
+    "arrow-icon-down": rotate,
+    "arrow-icon-up ": !rotate
+  });
+
   return _react2.default.createElement(
     "svg",
     {
@@ -93,7 +99,7 @@ var ArrowUpIcon = exports.ArrowUpIcon = function ArrowUpIcon(_ref5) {
       fill: "none",
       viewBox: "0 0 24 24",
       width: width || "12.166",
-      className: rotate ? "arrow-icon-down" : "arrow-icon-up",
+      className: headerClass,
       height: (width || 13.023) * 12.166 / 13.023,
       stroke: color || DEFAULT_GRAY
     },
@@ -110,13 +116,19 @@ var ChevronIcon = exports.ChevronIcon = function ChevronIcon(_ref6) {
   var width = _ref6.width,
       color = _ref6.color,
       rotate = _ref6.rotate;
+
+  var headerClass = (0, _utils.classNames)({
+    "chevron-icon-rotate-90": rotate,
+    "chevron-icon-rotate-0 ": !rotate
+  });
+
   return _react2.default.createElement(
     "svg",
     {
       width: width,
       height: width * 14.828 / 8.414,
       xmlns: "http://www.w3.org/2000/svg",
-      className: rotate ? "chevron-icon-rotate-90" : "chevron-icon-rotate-0 ",
+      className: headerClass,
       fill: "none",
       viewBox: "0 0 24 24",
       stroke: color || DEFAULT_GRAY

--- a/lib/components/Icons.js
+++ b/lib/components/Icons.js
@@ -24,7 +24,8 @@ var PlusIcon = exports.PlusIcon = function PlusIcon(_ref) {
       width: width,
       height: width * 448 / 352,
       className: (0, _utils.prefixClass)("icon icon-plus"),
-      viewBox: "0 0 352 448" },
+      viewBox: "0 0 352 448"
+    },
     _react2.default.createElement("title", null),
     _react2.default.createElement("g", { id: "icomoon-ignore" }),
     _react2.default.createElement("path", {
@@ -43,7 +44,8 @@ var CloseIcon = exports.CloseIcon = function CloseIcon(_ref2) {
       width: width,
       height: width * 448 / 352,
       className: (0, _utils.prefixClass)("icon icon-remove"),
-      viewBox: "0 0 352 448" },
+      viewBox: "0 0 352 448"
+    },
     _react2.default.createElement("title", null),
     _react2.default.createElement("g", { id: "icomoon-ignore" }),
     _react2.default.createElement("path", {
@@ -63,7 +65,8 @@ var DeleteIcon = exports.DeleteIcon = function DeleteIcon(_ref3) {
       xmlns: "http://www.w3.org/2000/svg",
       fill: "none",
       viewBox: "0 0 24 24",
-      stroke: color || DEFAULT_GRAY },
+      stroke: color || DEFAULT_GRAY
+    },
     _react2.default.createElement("path", {
       strokeLinecap: "round",
       strokeLinejoin: "round",
@@ -90,9 +93,10 @@ var ArrowUpIcon = exports.ArrowUpIcon = function ArrowUpIcon(_ref5) {
       fill: "none",
       viewBox: "0 0 24 24",
       width: width || "12.166",
-      transform: "rotate(" + (rotate ? rotate : 0) + ")",
+      className: rotate ? "arrow-icon-down" : "arrow-icon-up",
       height: (width || 13.023) * 12.166 / 13.023,
-      stroke: color || DEFAULT_GRAY },
+      stroke: color || DEFAULT_GRAY
+    },
     _react2.default.createElement("path", {
       strokeLinecap: "round",
       strokeLinejoin: "round",
@@ -112,10 +116,11 @@ var ChevronIcon = exports.ChevronIcon = function ChevronIcon(_ref6) {
       width: width,
       height: width * 14.828 / 8.414,
       xmlns: "http://www.w3.org/2000/svg",
-      transform: "rotate(" + (rotate ? rotate : 0) + ")",
+      className: rotate ? "chevron-icon-rotate-90" : "chevron-icon-rotate-0 ",
       fill: "none",
       viewBox: "0 0 24 24",
-      stroke: color || DEFAULT_GRAY },
+      stroke: color || DEFAULT_GRAY
+    },
     _react2.default.createElement("path", {
       strokeLinecap: "round",
       strokeLinejoin: "round",
@@ -135,7 +140,8 @@ var RequiredInfoIcon = exports.RequiredInfoIcon = function RequiredInfoIcon(_ref
       xmlns: "http://www.w3.org/2000/svg",
       width: width || "11.591",
       height: (width | 10.149) * 11.591 / 10.149,
-      viewBox: "0 0 11.591 10.149" },
+      viewBox: "0 0 11.591 10.149"
+    },
     _react2.default.createElement(
       "g",
       { transform: "translate(-1.038 -2.397)" },
@@ -179,7 +185,8 @@ var JsonIcon = exports.JsonIcon = function JsonIcon(_ref8) {
       xmlns: "http://www.w3.org/2000/svg",
       width: width || "16.57",
       height: (width | 13) * 16.57 / 13,
-      viewBox: "0 0 16.57 13" },
+      viewBox: "0 0 16.57 13"
+    },
     _react2.default.createElement(
       "g",
       { transform: "translate(-374 -272.36)" },

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -4,19 +4,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _extends =
-  Object.assign ||
-  function(target) {
-    for (var i = 1; i < arguments.length; i++) {
-      var source = arguments[i];
-      for (var key in source) {
-        if (Object.prototype.hasOwnProperty.call(source, key)) {
-          target[key] = source[key];
-        }
-      }
-    }
-    return target;
-  };
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 exports.toErrorList = toErrorList;
 exports.default = validateFormData;
@@ -30,23 +18,9 @@ var _AJV = require("./AJV");
 
 var _utils = require("./utils");
 
-function _interopRequireDefault(obj) {
-  return obj && obj.__esModule ? obj : { default: obj };
-}
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-function _defineProperty(obj, key, value) {
-  if (key in obj) {
-    Object.defineProperty(obj, key, {
-      value: value,
-      enumerable: true,
-      configurable: true,
-      writable: true
-    });
-  } else {
-    obj[key] = value;
-  }
-  return obj;
-}
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 // import { validateSchema } from "./validationUtils";
 
@@ -69,9 +43,9 @@ function toErrorSchema(errors) {
   if (!errors.length) {
     return {};
   }
-  return errors.reduce(function(errorSchema, error) {
+  return errors.reduce(function (errorSchema, error) {
     var property = error.property,
-      message = error.message;
+        message = error.message;
 
     var path = (0, _lodash2.default)(property);
     var parent = errorSchema;
@@ -87,11 +61,7 @@ function toErrorSchema(errors) {
     var _iteratorError = undefined;
 
     try {
-      for (
-        var _iterator = path.slice(0)[Symbol.iterator](), _step;
-        !(_iteratorNormalCompletion = (_step = _iterator.next()).done);
-        _iteratorNormalCompletion = true
-      ) {
+      for (var _iterator = path.slice(0)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
         var segment = _step.value;
 
         if (!(segment in parent)) {
@@ -127,21 +97,18 @@ function toErrorSchema(errors) {
 }
 
 function toErrorList(errorSchema) {
-  var fieldName =
-    arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : "root";
+  var fieldName = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : "root";
 
   // XXX: We should transform fieldName as a full field path string.
   var errorList = [];
   if ("__errors" in errorSchema) {
-    errorList = errorList.concat(
-      errorSchema.__errors.map(function(stack) {
-        return {
-          stack: fieldName + ": " + stack
-        };
-      })
-    );
+    errorList = errorList.concat(errorSchema.__errors.map(function (stack) {
+      return {
+        stack: fieldName + ": " + stack
+      };
+    }));
   }
-  return Object.keys(errorSchema).reduce(function(acc, key) {
+  return Object.keys(errorSchema).reduce(function (acc, key) {
     if (key !== "__errors") {
       acc = acc.concat(toErrorList(errorSchema[key], key));
     }
@@ -160,38 +127,26 @@ function createErrorHandler(formData) {
     }
   };
   if ((0, _utils.isObject)(formData)) {
-    return Object.keys(formData).reduce(function(acc, key) {
-      return _extends(
-        {},
-        acc,
-        _defineProperty({}, key, createErrorHandler(formData[key]))
-      );
+    return Object.keys(formData).reduce(function (acc, key) {
+      return _extends({}, acc, _defineProperty({}, key, createErrorHandler(formData[key])));
     }, handler);
   }
   if (Array.isArray(formData)) {
-    return formData.reduce(function(acc, value, key) {
-      return _extends(
-        {},
-        acc,
-        _defineProperty({}, key, createErrorHandler(value))
-      );
+    return formData.reduce(function (acc, value, key) {
+      return _extends({}, acc, _defineProperty({}, key, createErrorHandler(value)));
     }, handler);
   }
   return handler;
 }
 
 function unwrapErrorHandler(errorHandler) {
-  return Object.keys(errorHandler).reduce(function(acc, key) {
+  return Object.keys(errorHandler).reduce(function (acc, key) {
     if (key === "addError") {
       return acc;
     } else if (key === "__errors") {
       return _extends({}, acc, _defineProperty({}, key, errorHandler[key]));
     }
-    return _extends(
-      {},
-      acc,
-      _defineProperty({}, key, unwrapErrorHandler(errorHandler[key]))
-    );
+    return _extends({}, acc, _defineProperty({}, key, unwrapErrorHandler(errorHandler[key])));
   }, {});
 }
 
@@ -204,11 +159,11 @@ function transformAjvErrors(errors) {
     return [];
   }
 
-  return errors.map(function(e) {
+  return errors.map(function (e) {
     var dataPath = e.dataPath,
-      keyword = e.keyword,
-      message = e.message,
-      params = e.params;
+        keyword = e.keyword,
+        message = e.message,
+        params = e.params;
 
     var property = "" + dataPath;
 
@@ -228,14 +183,7 @@ function transformAjvErrors(errors) {
  * function, which receives the form data and an `errorHandler` object that
  * will be used to add custom validation errors for each field.
  */
-function validateFormData(
-  formData,
-  schema,
-  customValidate,
-  transformErrors,
-  originalFormData,
-  definitions
-) {
+function validateFormData(formData, schema, customValidate, transformErrors, originalFormData, definitions) {
   var ajv = _AJV.AJV.getInstance();
   // validateSchema(schema, formData, originalFormData, ajv, definitions);
   if (!ajv) {
@@ -257,11 +205,7 @@ function validateFormData(
 
   var errorHandler = customValidate(formData, createErrorHandler(formData));
   var userErrorSchema = unwrapErrorHandler(errorHandler);
-  var newErrorSchema = (0, _utils.mergeObjects)(
-    errorSchema,
-    userErrorSchema,
-    true
-  );
+  var newErrorSchema = (0, _utils.mergeObjects)(errorSchema, userErrorSchema, true);
   // XXX: The errors list produced is not fully compliant with the format
   // exposed by the jsonschema lib, which contains full field paths and other
   // properties.

--- a/src/components/Icons.js
+++ b/src/components/Icons.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { prefixClass } from "../utils";
+import { classNames, prefixClass } from "../utils";
 
 const DEFAULT_GRAY = "#3E445D";
 
@@ -55,43 +55,57 @@ export const DeleteIcon = ({ width, color }) => (
 export const ArrowDownIcon = ({ width, color }) =>
   ArrowUpIcon({ width, color, rotate: 180 });
 
-export const ArrowUpIcon = ({ width, color, rotate }) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    width={width || "12.166"}
-    className={rotate ? "arrow-icon-down" : "arrow-icon-up"}
-    height={((width || 13.023) * 12.166) / 13.023}
-    stroke={color || DEFAULT_GRAY}
-  >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth="2"
-      d="M5 10l7-7m0 0l7 7m-7-7v18"
-    />
-  </svg>
-);
+export const ArrowUpIcon = ({ width, color, rotate }) => {
+  const svgClass = classNames({
+    "arrow-icon-down": rotate,
+    "arrow-icon-up ": !rotate
+  });
 
-export const ChevronIcon = ({ width, color, rotate }) => (
-  <svg
-    width={width}
-    height={(width * 14.828) / 8.414}
-    xmlns="http://www.w3.org/2000/svg"
-    className={rotate ? "chevron-icon-rotate-90" : "chevron-icon-rotate-0 "}
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke={color || DEFAULT_GRAY}
-  >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth="2"
-      d="M19 9l-7 7-7-7"
-    />
-  </svg>
-);
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      width={width || "12.166"}
+      className={svgClass}
+      height={((width || 13.023) * 12.166) / 13.023}
+      stroke={color || DEFAULT_GRAY}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+        d="M5 10l7-7m0 0l7 7m-7-7v18"
+      />
+    </svg>
+  );
+};
+
+export const ChevronIcon = ({ width, color, rotate }) => {
+  const svgClass = classNames({
+    "chevron-icon-rotate-90": rotate,
+    "chevron-icon-rotate-0 ": !rotate
+  });
+
+  return (
+    <svg
+      width={width}
+      height={(width * 14.828) / 8.414}
+      xmlns="http://www.w3.org/2000/svg"
+      className={svgClass}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke={color || DEFAULT_GRAY}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+        d="M19 9l-7 7-7-7"
+      />
+    </svg>
+  );
+};
 
 export const RequiredInfoIcon = ({ width, color }) => {
   return (

--- a/src/components/Icons.js
+++ b/src/components/Icons.js
@@ -8,7 +8,8 @@ export const PlusIcon = ({ width, color }) => (
     width={width}
     height={(width * 448) / 352}
     className={prefixClass("icon icon-plus")}
-    viewBox="0 0 352 448">
+    viewBox="0 0 352 448"
+  >
     <title />
     <g id="icomoon-ignore" />
     <path
@@ -23,7 +24,8 @@ export const CloseIcon = ({ width, color }) => (
     width={width}
     height={(width * 448) / 352}
     className={prefixClass("icon icon-remove")}
-    viewBox="0 0 352 448">
+    viewBox="0 0 352 448"
+  >
     <title />
     <g id="icomoon-ignore" />
     <path
@@ -39,7 +41,8 @@ export const DeleteIcon = ({ width, color }) => (
     xmlns="http://www.w3.org/2000/svg"
     fill="none"
     viewBox="0 0 24 24"
-    stroke={color || DEFAULT_GRAY}>
+    stroke={color || DEFAULT_GRAY}
+  >
     <path
       strokeLinecap="round"
       strokeLinejoin="round"
@@ -58,9 +61,10 @@ export const ArrowUpIcon = ({ width, color, rotate }) => (
     fill="none"
     viewBox="0 0 24 24"
     width={width || "12.166"}
-    transform={`rotate(${rotate ? rotate : 0})`}
+    className={rotate ? "arrow-icon-down" : "arrow-icon-up"}
     height={((width || 13.023) * 12.166) / 13.023}
-    stroke={color || DEFAULT_GRAY}>
+    stroke={color || DEFAULT_GRAY}
+  >
     <path
       strokeLinecap="round"
       strokeLinejoin="round"
@@ -75,10 +79,11 @@ export const ChevronIcon = ({ width, color, rotate }) => (
     width={width}
     height={(width * 14.828) / 8.414}
     xmlns="http://www.w3.org/2000/svg"
-    transform={`rotate(${rotate ? rotate : 0})`}
+    className={rotate ? "chevron-icon-rotate-90" : "chevron-icon-rotate-0 "}
     fill="none"
     viewBox="0 0 24 24"
-    stroke={color || DEFAULT_GRAY}>
+    stroke={color || DEFAULT_GRAY}
+  >
     <path
       strokeLinecap="round"
       strokeLinejoin="round"
@@ -94,7 +99,8 @@ export const RequiredInfoIcon = ({ width, color }) => {
       xmlns="http://www.w3.org/2000/svg"
       width={width || "11.591"}
       height={((width | 10.149) * 11.591) / 10.149}
-      viewBox="0 0 11.591 10.149">
+      viewBox="0 0 11.591 10.149"
+    >
       <g transform="translate(-1.038 -2.397)">
         <path
           d="M5.968,3.384,1.687,10.53a1.011,1.011,0,0,0,.864,1.516h8.562a1.011,1.011,0,0,0,.864-1.516L7.7,3.384a1.011,1.011,0,0,0-1.728,0Z"
@@ -133,7 +139,8 @@ export const JsonIcon = ({ width, color }) => {
       xmlns="http://www.w3.org/2000/svg"
       width={width || "16.57"}
       height={((width | 13) * 16.57) / 13}
-      viewBox="0 0 16.57 13">
+      viewBox="0 0 16.57 13"
+    >
       <g transform="translate(-374 -272.36)">
         <path
           d="M17.59,16.55v-2.6a.635.635,0,0,1,.618-.65.651.651,0,0,0,0-1.3,1.906,1.906,0,0,0-1.854,1.95v2.6a1.27,1.27,0,0,1-1.236,1.3.651.651,0,0,0,0,1.3,1.27,1.27,0,0,1,1.236,1.3v2.6A1.906,1.906,0,0,0,18.208,25a.651.651,0,0,0,0-1.3.635.635,0,0,1-.618-.65v-2.6a2.641,2.641,0,0,0-.854-1.95A2.641,2.641,0,0,0,17.59,16.55Z"


### PR DESCRIPTION
### Reasons for making this change

[Please describe them here]

Both of the icons are shown upward and on click, sections are not moving up and down.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
