### PR TITLE
Added data type to oneOf fields.

### DIFF
--- a/lib/components/Icons.js
+++ b/lib/components/Icons.js
@@ -266,7 +266,7 @@ var TagLinkSvg = exports.TagLinkSvg = function TagLinkSvg(_ref9) {
           d: "M10,7.369a2.439,2.439,0,0,0,3.678.263l1.463-1.463a2.439,2.439,0,1,0-3.449-3.449l-.839.834",
           transform: "translate(-4.1 0)",
           fill: "none",
-          stroke: color || "#fff",
+          stroke: "",
           strokeLinecap: "round",
           strokeLinejoin: "round",
           strokeWidth: "1.2"
@@ -277,7 +277,7 @@ var TagLinkSvg = exports.TagLinkSvg = function TagLinkSvg(_ref9) {
           d: "M7.851,9.973A2.439,2.439,0,0,0,4.173,9.71L2.71,11.173a2.439,2.439,0,1,0,3.449,3.449l.834-.834",
           transform: "translate(0 -3.58)",
           fill: "none",
-          stroke: color || "#fff",
+          stroke: "",
           strokeLinecap: "round",
           strokeLinejoin: "round",
           strokeWidth: "1.2"

--- a/lib/components/Icons.js
+++ b/lib/components/Icons.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.JsonIcon = exports.RequiredInfoIcon = exports.ChevronIcon = exports.ArrowUpIcon = exports.ArrowDownIcon = exports.DeleteIcon = exports.CloseIcon = exports.PlusIcon = undefined;
+exports.TagLinkSvg = exports.JsonIcon = exports.RequiredInfoIcon = exports.ChevronIcon = exports.ArrowUpIcon = exports.ArrowDownIcon = exports.DeleteIcon = exports.CloseIcon = exports.PlusIcon = undefined;
 
 var _react = require("react");
 
@@ -228,6 +228,59 @@ var JsonIcon = exports.JsonIcon = function JsonIcon(_ref8) {
           r: "0.901",
           transform: "translate(0)",
           fill: color || "#3E445D"
+        })
+      )
+    )
+  );
+};
+
+var TagLinkSvg = exports.TagLinkSvg = function TagLinkSvg(_ref9) {
+  var width = _ref9.width,
+      color = _ref9.color;
+
+  return _react2.default.createElement(
+    "svg",
+    {
+      xmlns: "http://www.w3.org/2000/svg",
+      width: width || "10",
+      height: width || "10",
+      viewBox: "0 0 10.961 10.951"
+    },
+    _react2.default.createElement(
+      "g",
+      {
+        id: "Group_2268",
+        "data-name": "Group 2268",
+        transform: "translate(-565.026 -707.524)"
+      },
+      _react2.default.createElement(
+        "g",
+        {
+          id: "link_4_",
+          "data-name": "link (4)",
+          transform: "translate(563.631 706.119)"
+        },
+        _react2.default.createElement("path", {
+          id: "Path_36573",
+          "data-name": "Path 36573",
+          d: "M10,7.369a2.439,2.439,0,0,0,3.678.263l1.463-1.463a2.439,2.439,0,1,0-3.449-3.449l-.839.834",
+          transform: "translate(-4.1 0)",
+          fill: "none",
+          stroke: color || "#fff",
+          strokeLinecap: "round",
+          strokeLinejoin: "round",
+          strokeWidth: "1.2"
+        }),
+        _react2.default.createElement("path", {
+          id: "Path_36574",
+          "data-name": "Path 36574",
+          d: "M7.851,9.973A2.439,2.439,0,0,0,4.173,9.71L2.71,11.173a2.439,2.439,0,1,0,3.449,3.449l.834-.834",
+          transform: "translate(0 -3.58)",
+          fill: "none",
+          stroke: color || "#fff",
+          strokeLinecap: "round",
+          strokeLinejoin: "round",
+          strokeWidth: "1.2"
         })
       )
     )

--- a/lib/components/fields/DiscriminatorField.js
+++ b/lib/components/fields/DiscriminatorField.js
@@ -378,7 +378,10 @@ var DiscriminatorField = function (_React$Component) {
           fieldProps = _props.fieldProps,
           fromDiscriminator = _props.fromDiscriminator,
           disabled = _props.disabled,
-          tagsTitle = _props.tagsTitle;
+          tagsTitle = _props.tagsTitle,
+          registry = _props.registry;
+      var dxInterface = registry.dxInterface;
+      var renderToolTip = dxInterface.renderToolTip;
       var _state = this.state,
           selectedSchema = _state.selectedSchema,
           checked = _state.checked,
@@ -415,7 +418,8 @@ var DiscriminatorField = function (_React$Component) {
             value: selectedSchema,
             title: tagsTitle || getMultipleLabel(schema),
             options: selectOptions,
-            onChange: this.selectOnChange
+            onChange: this.selectOnChange,
+            renderToolTip: renderToolTip
           }),
           this.renderSchema(depth)
         ) : null

--- a/lib/components/fields/DiscriminatorField.js
+++ b/lib/components/fields/DiscriminatorField.js
@@ -323,6 +323,7 @@ var DiscriminatorField = function (_React$Component) {
           formData = _this$props6.formData,
           registry = _this$props6.registry;
       var dxInterface = registry.dxInterface;
+      var linkMapper = dxInterface.linkMapper;
       var _schema$typeCombinato2 = schema.typeCombinatorTypes,
           typeCombinatorTypes = _schema$typeCombinato2 === undefined ? typeCombinatorTypesFromProps : _schema$typeCombinato2;
 
@@ -341,13 +342,17 @@ var DiscriminatorField = function (_React$Component) {
         }
 
         var type = typeCombinatorTypes && typeCombinatorTypes[index].DataType;
+
+        var linkTo = typeCombinatorTypes && typeCombinatorTypes[index].LinkTo;
+
         var label = type ? type : getMultipleLabel(schema) || schema.type || "";
 
         selectOptions.push({
           label: label,
           value: {
             index: index,
-            schema: schema
+            schema: schema,
+            linkTo: linkTo ? linkMapper(linkTo) : null
           }
         });
 

--- a/lib/components/widgets/TagSelector/index.js
+++ b/lib/components/widgets/TagSelector/index.js
@@ -20,6 +20,10 @@ var _reactSelect2 = _interopRequireDefault(_reactSelect);
 
 var _utils = require("../../../utils");
 
+var _context = require("../../context");
+
+var _Icons = require("../../Icons");
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -56,6 +60,12 @@ var TagSelector = function (_React$Component) {
         };
       };
 
+      var selectValue = options && options[value.index];
+
+      var selectedLabel = selectValue && selectValue.label;
+
+      var selectLinkTo = selectValue && selectValue.value.linkTo;
+
       return _react2.default.createElement(
         "div",
         { className: "tag-selector " + className },
@@ -68,14 +78,40 @@ var TagSelector = function (_React$Component) {
           "div",
           { className: "__tags-wrapper --variant-tag" },
           options.map(function (option, index) {
+            var value = option.value;
+
+            var linkTo = value.linkTo;
             return _react2.default.createElement(
-              "span",
-              {
-                key: "option-item-" + index + "-" + option.label,
-                className: "--tag " + (value.index === index ? "--active" : ""),
-                onClick: onClick(option)
-              },
-              option.label
+              "div",
+              { className: "tag-wrapper-item" },
+              _react2.default.createElement(
+                "span",
+                {
+                  key: "option-item-" + index + "-" + option.label,
+                  className: "--tag tag-label " + (value.index === index ? "--active" : ""),
+                  onClick: onClick(option)
+                },
+                option.label
+              ),
+              linkTo && value.index === index && _react2.default.createElement(
+                _context.ContextConsumer,
+                null,
+                function (_ref) {
+                  var onRouteChange = _ref.onRouteChange;
+                  return _react2.default.createElement(
+                    "span",
+                    {
+                      key: "option-item-" + index + "-" + option.label,
+                      className: "--tag tag-link " + (value.index === index ? "--active" : ""),
+                      onClick: function onClick() {
+                        console.log(linkTo);
+                        onRouteChange(linkTo);
+                      }
+                    },
+                    _react2.default.createElement(_Icons.TagLinkSvg, { width: "10", color: "#fff" })
+                  );
+                }
+              )
             );
           })
         ),
@@ -85,13 +121,32 @@ var TagSelector = function (_React$Component) {
           _react2.default.createElement(_reactSelect2.default, {
             className: "" + (0, _utils.prefixClass)("form-control"),
             classNamePrefix: "react-select",
-            value: options[value.index],
+            value: selectValue,
             options: options,
-            onChange: function onChange(_ref) {
-              var value = _ref.value;
+            onChange: function onChange(_ref2) {
+              var value = _ref2.value;
               return _onChange(value);
             }
-          })
+          }),
+          _react2.default.createElement(
+            "span",
+            { className: "tags-variant-select-link" },
+            _react2.default.createElement(_Icons.TagLinkSvg, { width: "10", color: "#0062ff" }),
+            _react2.default.createElement(
+              _context.ContextConsumer,
+              null,
+              function (_ref3) {
+                var onRouteChange = _ref3.onRouteChange;
+                return _react2.default.createElement(
+                  "a",
+                  { onClick: function onClick() {
+                      return onRouteChange(selectLinkTo);
+                    } },
+                  selectedLabel
+                );
+              }
+            )
+          )
         )
       );
     }

--- a/lib/components/widgets/TagSelector/index.js
+++ b/lib/components/widgets/TagSelector/index.js
@@ -78,9 +78,7 @@ var TagSelector = function (_React$Component) {
           "div",
           { className: "__tags-wrapper --variant-tag" },
           options.map(function (option, index) {
-            var value = option.value;
-
-            var linkTo = value.linkTo;
+            var linkTo = option.value.linkTo;
             return _react2.default.createElement(
               "div",
               { className: "tag-wrapper-item" },

--- a/lib/components/widgets/TagSelector/index.js
+++ b/lib/components/widgets/TagSelector/index.js
@@ -102,7 +102,6 @@ var TagSelector = function (_React$Component) {
                       key: "option-item-" + index + "-" + option.label,
                       className: "--tag tag-link " + (value.index === index ? "--active" : ""),
                       onClick: function onClick() {
-                        console.log(linkTo);
                         onRouteChange(linkTo);
                       }
                     },

--- a/lib/components/widgets/TagSelector/index.js
+++ b/lib/components/widgets/TagSelector/index.js
@@ -79,6 +79,19 @@ var TagSelector = function (_React$Component) {
           { className: "__tags-wrapper --variant-tag" },
           options.map(function (option, index) {
             var linkTo = option.value.linkTo;
+
+            var classTagLabel = (0, _utils.classNames)({
+              "--tag": true,
+              " tag-label": true,
+              "--active": value.index === index
+            });
+
+            var classTagLink = (0, _utils.classNames)({
+              "--tag": true,
+              "tag-link": true,
+              "--active": value.index === index
+            });
+
             return _react2.default.createElement(
               "div",
               { className: "tag-wrapper-item" },
@@ -86,7 +99,7 @@ var TagSelector = function (_React$Component) {
                 "span",
                 {
                   key: "option-item-" + index + "-" + option.label,
-                  className: "--tag tag-label " + (value.index === index ? "--active" : ""),
+                  className: classTagLabel,
                   onClick: onClick(option)
                 },
                 option.label
@@ -100,7 +113,7 @@ var TagSelector = function (_React$Component) {
                     "span",
                     {
                       key: "option-item-" + index + "-" + option.label,
-                      className: "--tag tag-link " + (value.index === index ? "--active" : ""),
+                      className: classTagLink,
                       onClick: function onClick() {
                         onRouteChange(linkTo);
                       }
@@ -128,7 +141,7 @@ var TagSelector = function (_React$Component) {
           _react2.default.createElement(
             "span",
             { className: "tags-variant-select-link" },
-            _react2.default.createElement(_Icons.TagLinkSvg, { width: "10", color: "#0062ff" }),
+            _react2.default.createElement(_Icons.TagLinkSvg, { width: "10", color: "#00c7d4" }),
             _react2.default.createElement(
               _context.ContextConsumer,
               null,

--- a/lib/components/widgets/TagSelector/index.js
+++ b/lib/components/widgets/TagSelector/index.js
@@ -53,7 +53,8 @@ var TagSelector = function (_React$Component) {
           _props$value = _props.value,
           value = _props$value === undefined ? options[0] : _props$value,
           _props$className = _props.className,
-          className = _props$className === undefined ? "" : _props$className;
+          className = _props$className === undefined ? "" : _props$className,
+          renderToolTip = _props.renderToolTip;
 
 
       var onClick = function onClick(option) {
@@ -64,7 +65,7 @@ var TagSelector = function (_React$Component) {
 
       var selectValue = options && options[value.index];
 
-      // const selectedLabel = selectValue && selectValue.label;
+      var selectedLabel = selectValue && selectValue.label;
 
       var selectLinkTo = selectValue && selectValue.value.linkTo;
 
@@ -112,7 +113,7 @@ var TagSelector = function (_React$Component) {
                 null,
                 function (_ref) {
                   var onRouteChange = _ref.onRouteChange;
-                  return _react2.default.createElement(
+                  return renderToolTip(_react2.default.createElement(
                     "span",
                     {
                       key: "option-item-" + index + "-" + option.label,
@@ -122,7 +123,7 @@ var TagSelector = function (_React$Component) {
                       }
                     },
                     _react2.default.createElement(_Icons.TagLinkSvg, { width: "10" })
-                  );
+                  ), VIEW_MODEL);
                 }
               )
             );
@@ -151,19 +152,20 @@ var TagSelector = function (_React$Component) {
             _react2.default.createElement(
               "span",
               { className: "tags-variant-select-link" },
-              _react2.default.createElement(_Icons.TagLinkSvg, { width: "10" }),
               _react2.default.createElement(
                 _context.ContextConsumer,
                 null,
                 function (_ref3) {
                   var onRouteChange = _ref3.onRouteChange;
-                  return _react2.default.createElement(
+                  return renderToolTip(_react2.default.createElement(
                     "a",
                     { onClick: function onClick() {
                         return onRouteChange(selectLinkTo);
                       } },
+                    _react2.default.createElement(_Icons.TagLinkSvg, { width: "10" }),
+                    " ",
                     VIEW_MODEL
-                  );
+                  ), selectedLabel);
                 }
               )
             )

--- a/lib/components/widgets/TagSelector/index.js
+++ b/lib/components/widgets/TagSelector/index.js
@@ -32,6 +32,8 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
+var VIEW_MODEL = "View Model";
+
 var TagSelector = function (_React$Component) {
   _inherits(TagSelector, _React$Component);
 
@@ -62,7 +64,7 @@ var TagSelector = function (_React$Component) {
 
       var selectValue = options && options[value.index];
 
-      var selectedLabel = selectValue && selectValue.label;
+      // const selectedLabel = selectValue && selectValue.label;
 
       var selectLinkTo = selectValue && selectValue.value.linkTo;
 
@@ -89,7 +91,8 @@ var TagSelector = function (_React$Component) {
             var classTagLink = (0, _utils.classNames)({
               "--tag": true,
               "tag-link": true,
-              "--active": value.index === index
+              "--active": value.index === index,
+              "tag-selector-button-link": true
             });
 
             return _react2.default.createElement(
@@ -118,7 +121,7 @@ var TagSelector = function (_React$Component) {
                         onRouteChange(linkTo);
                       }
                     },
-                    _react2.default.createElement(_Icons.TagLinkSvg, { width: "10", color: "#fff" })
+                    _react2.default.createElement(_Icons.TagLinkSvg, { width: "10" })
                   );
                 }
               )
@@ -128,33 +131,41 @@ var TagSelector = function (_React$Component) {
         _react2.default.createElement(
           "div",
           { className: "__tags-wrapper --variant-select" },
-          _react2.default.createElement(_reactSelect2.default, {
-            className: "" + (0, _utils.prefixClass)("form-control"),
-            classNamePrefix: "react-select",
-            value: selectValue,
-            options: options,
-            onChange: function onChange(_ref2) {
-              var value = _ref2.value;
-              return _onChange(value);
-            }
-          }),
           _react2.default.createElement(
-            "span",
-            { className: "tags-variant-select-link" },
-            _react2.default.createElement(_Icons.TagLinkSvg, { width: "10", color: "#00c7d4" }),
-            _react2.default.createElement(
-              _context.ContextConsumer,
-              null,
-              function (_ref3) {
-                var onRouteChange = _ref3.onRouteChange;
-                return _react2.default.createElement(
-                  "a",
-                  { onClick: function onClick() {
-                      return onRouteChange(selectLinkTo);
-                    } },
-                  selectedLabel
-                );
+            "div",
+            null,
+            _react2.default.createElement(_reactSelect2.default, {
+              className: "" + (0, _utils.prefixClass)("form-control"),
+              classNamePrefix: "react-select",
+              value: selectValue,
+              options: options,
+              onChange: function onChange(_ref2) {
+                var value = _ref2.value;
+                return _onChange(value);
               }
+            })
+          ),
+          _react2.default.createElement(
+            "div",
+            null,
+            _react2.default.createElement(
+              "span",
+              { className: "tags-variant-select-link" },
+              _react2.default.createElement(_Icons.TagLinkSvg, { width: "10" }),
+              _react2.default.createElement(
+                _context.ContextConsumer,
+                null,
+                function (_ref3) {
+                  var onRouteChange = _ref3.onRouteChange;
+                  return _react2.default.createElement(
+                    "a",
+                    { onClick: function onClick() {
+                        return onRouteChange(selectLinkTo);
+                      } },
+                    VIEW_MODEL
+                  );
+                }
+              )
             )
           )
         )

--- a/src/components/Icons.js
+++ b/src/components/Icons.js
@@ -211,7 +211,7 @@ export const TagLinkSvg = ({ width, color }) => {
             d="M10,7.369a2.439,2.439,0,0,0,3.678.263l1.463-1.463a2.439,2.439,0,1,0-3.449-3.449l-.839.834"
             transform="translate(-4.1 0)"
             fill="none"
-            stroke={color || "#fff"}
+            stroke=""
             strokeLinecap="round"
             strokeLinejoin="round"
             strokeWidth="1.2"
@@ -222,7 +222,7 @@ export const TagLinkSvg = ({ width, color }) => {
             d="M7.851,9.973A2.439,2.439,0,0,0,4.173,9.71L2.71,11.173a2.439,2.439,0,1,0,3.449,3.449l.834-.834"
             transform="translate(0 -3.58)"
             fill="none"
-            stroke={color || "#fff"}
+            stroke=""
             strokeLinecap="round"
             strokeLinejoin="round"
             strokeWidth="1.2"

--- a/src/components/Icons.js
+++ b/src/components/Icons.js
@@ -186,3 +186,49 @@ export const JsonIcon = ({ width, color }) => {
     </svg>
   );
 };
+
+export const TagLinkSvg = ({ width, color }) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={width || "10"}
+      height={width || "10"}
+      viewBox="0 0 10.961 10.951"
+    >
+      <g
+        id="Group_2268"
+        data-name="Group 2268"
+        transform="translate(-565.026 -707.524)"
+      >
+        <g
+          id="link_4_"
+          data-name="link (4)"
+          transform="translate(563.631 706.119)"
+        >
+          <path
+            id="Path_36573"
+            data-name="Path 36573"
+            d="M10,7.369a2.439,2.439,0,0,0,3.678.263l1.463-1.463a2.439,2.439,0,1,0-3.449-3.449l-.839.834"
+            transform="translate(-4.1 0)"
+            fill="none"
+            stroke={color || "#fff"}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1.2"
+          />
+          <path
+            id="Path_36574"
+            data-name="Path 36574"
+            d="M7.851,9.973A2.439,2.439,0,0,0,4.173,9.71L2.71,11.173a2.439,2.439,0,1,0,3.449,3.449l.834-.834"
+            transform="translate(0 -3.58)"
+            fill="none"
+            stroke={color || "#fff"}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1.2"
+          />
+        </g>
+      </g>
+    </svg>
+  );
+};

--- a/src/components/fields/DiscriminatorField.js
+++ b/src/components/fields/DiscriminatorField.js
@@ -432,9 +432,14 @@ class DiscriminatorField extends React.Component {
       fieldProps,
       fromDiscriminator,
       disabled,
-      tagsTitle
+      tagsTitle,
+      registry
     } = this.props;
+    const { dxInterface } = registry;
+    const { renderToolTip } = dxInterface;
+
     const { selectedSchema, checked, optional } = this.state;
+
     const { selectOptions, charCounts } = this.getSelectOptions();
 
     const isOneOfOrAnyOf =
@@ -474,6 +479,7 @@ class DiscriminatorField extends React.Component {
               title={tagsTitle || getMultipleLabel(schema)}
               options={selectOptions}
               onChange={this.selectOnChange}
+              renderToolTip={renderToolTip}
             />
             {this.renderSchema(depth)}
           </fieldset>

--- a/src/components/fields/DiscriminatorField.js
+++ b/src/components/fields/DiscriminatorField.js
@@ -379,6 +379,9 @@ class DiscriminatorField extends React.Component {
       registry
     } = this.props;
     const { dxInterface } = registry;
+
+    const { linkMapper } = dxInterface;
+
     const { typeCombinatorTypes = typeCombinatorTypesFromProps } = schema;
 
     const multipleSchema = schema.oneOf || schema.anyOf;
@@ -400,6 +403,9 @@ class DiscriminatorField extends React.Component {
         }
 
         const type = typeCombinatorTypes && typeCombinatorTypes[index].DataType;
+
+        const linkTo = typeCombinatorTypes && typeCombinatorTypes[index].LinkTo;
+
         const label = type
           ? type
           : getMultipleLabel(schema) || schema.type || "";
@@ -408,7 +414,8 @@ class DiscriminatorField extends React.Component {
           label,
           value: {
             index: index,
-            schema: schema
+            schema: schema,
+            linkTo: linkTo ? linkMapper(linkTo) : null
           }
         });
 

--- a/src/components/widgets/TagSelector/index.js
+++ b/src/components/widgets/TagSelector/index.js
@@ -6,6 +6,8 @@ import { prefixClass, classNames } from "../../../utils";
 import { ContextConsumer } from "../../context";
 import { TagLinkSvg } from "../../Icons";
 
+const VIEW_MODEL = "View Model";
+
 class TagSelector extends React.Component {
   render() {
     const {
@@ -24,7 +26,7 @@ class TagSelector extends React.Component {
 
     const selectValue = options && options[value.index];
 
-    const selectedLabel = selectValue && selectValue.label;
+    // const selectedLabel = selectValue && selectValue.label;
 
     const selectLinkTo = selectValue && selectValue.value.linkTo;
 
@@ -44,7 +46,8 @@ class TagSelector extends React.Component {
             const classTagLink = classNames({
               "--tag": true,
               "tag-link": true,
-              "--active": value.index === index
+              "--active": value.index === index,
+              "tag-selector-button-link": true
             });
 
             return (
@@ -66,7 +69,7 @@ class TagSelector extends React.Component {
                           onRouteChange(linkTo);
                         }}
                       >
-                        <TagLinkSvg width="10" color="#fff" />
+                        <TagLinkSvg width="10" />
                       </span>
                     )}
                   </ContextConsumer>
@@ -76,23 +79,27 @@ class TagSelector extends React.Component {
           })}
         </div>
         <div className="__tags-wrapper --variant-select">
-          <Select
-            className={`${prefixClass("form-control")}`}
-            classNamePrefix="react-select"
-            value={selectValue}
-            options={options}
-            onChange={({ value }) => onChange(value)}
-          />
-          <span className="tags-variant-select-link">
-            <TagLinkSvg width="10" color="#00c7d4" />
-            <ContextConsumer>
-              {({ onRouteChange }) => (
-                <a onClick={() => onRouteChange(selectLinkTo)}>
-                  {selectedLabel}
-                </a>
-              )}
-            </ContextConsumer>
-          </span>
+          <div>
+            <Select
+              className={`${prefixClass("form-control")}`}
+              classNamePrefix="react-select"
+              value={selectValue}
+              options={options}
+              onChange={({ value }) => onChange(value)}
+            />
+          </div>
+          <div>
+            <span className="tags-variant-select-link">
+              <TagLinkSvg width="10" />
+              <ContextConsumer>
+                {({ onRouteChange }) => (
+                  <a onClick={() => onRouteChange(selectLinkTo)}>
+                    {VIEW_MODEL}
+                  </a>
+                )}
+              </ContextConsumer>
+            </span>
+          </div>
         </div>
       </div>
     );

--- a/src/components/widgets/TagSelector/index.js
+++ b/src/components/widgets/TagSelector/index.js
@@ -15,7 +15,8 @@ class TagSelector extends React.Component {
       options,
       onChange,
       value = options[0],
-      className = ""
+      className = "",
+      renderToolTip
     } = this.props;
 
     const onClick = option => {
@@ -26,7 +27,7 @@ class TagSelector extends React.Component {
 
     const selectValue = options && options[value.index];
 
-    // const selectedLabel = selectValue && selectValue.label;
+    const selectedLabel = selectValue && selectValue.label;
 
     const selectLinkTo = selectValue && selectValue.value.linkTo;
 
@@ -61,17 +62,20 @@ class TagSelector extends React.Component {
                 </span>
                 {linkTo && value.index === index && (
                   <ContextConsumer>
-                    {({ onRouteChange }) => (
-                      <span
-                        key={`option-item-${index}-${option.label}`}
-                        className={classTagLink}
-                        onClick={() => {
-                          onRouteChange(linkTo);
-                        }}
-                      >
-                        <TagLinkSvg width="10" />
-                      </span>
-                    )}
+                    {({ onRouteChange }) =>
+                      renderToolTip(
+                        <span
+                          key={`option-item-${index}-${option.label}`}
+                          className={classTagLink}
+                          onClick={() => {
+                            onRouteChange(linkTo);
+                          }}
+                        >
+                          <TagLinkSvg width="10" />
+                        </span>,
+                        VIEW_MODEL
+                      )
+                    }
                   </ContextConsumer>
                 )}
               </div>
@@ -90,13 +94,15 @@ class TagSelector extends React.Component {
           </div>
           <div>
             <span className="tags-variant-select-link">
-              <TagLinkSvg width="10" />
               <ContextConsumer>
-                {({ onRouteChange }) => (
-                  <a onClick={() => onRouteChange(selectLinkTo)}>
-                    {VIEW_MODEL}
-                  </a>
-                )}
+                {({ onRouteChange }) =>
+                  renderToolTip(
+                    <a onClick={() => onRouteChange(selectLinkTo)}>
+                      <TagLinkSvg width="10" /> {VIEW_MODEL}
+                    </a>,
+                    selectedLabel
+                  )
+                }
               </ContextConsumer>
             </span>
           </div>

--- a/src/components/widgets/TagSelector/index.js
+++ b/src/components/widgets/TagSelector/index.js
@@ -33,8 +33,7 @@ class TagSelector extends React.Component {
         <span className="__title --tag">{title}</span>
         <div className="__tags-wrapper --variant-tag">
           {options.map((option, index) => {
-            const { value } = option;
-            const linkTo = value.linkTo;
+            const linkTo = option.value.linkTo;
             return (
               <div className="tag-wrapper-item">
                 <span

--- a/src/components/widgets/TagSelector/index.js
+++ b/src/components/widgets/TagSelector/index.js
@@ -3,6 +3,8 @@ import React from "react";
 import Select from "react-select";
 
 import { prefixClass } from "../../../utils";
+import { ContextConsumer } from "../../context";
+import { TagLinkSvg } from "../../Icons";
 
 class TagSelector extends React.Component {
   render() {
@@ -20,28 +22,70 @@ class TagSelector extends React.Component {
       };
     };
 
+    const selectValue = options && options[value.index];
+
+    const selectedLabel = selectValue && selectValue.label;
+
+    const selectLinkTo = selectValue && selectValue.value.linkTo;
+
     return (
       <div className={`tag-selector ${className}`}>
         <span className="__title --tag">{title}</span>
         <div className="__tags-wrapper --variant-tag">
-          {options.map((option, index) => (
-            <span
-              key={`option-item-${index}-${option.label}`}
-              className={`--tag ${value.index === index ? "--active" : ""}`}
-              onClick={onClick(option)}
-            >
-              {option.label}
-            </span>
-          ))}
+          {options.map((option, index) => {
+            const { value } = option;
+            const linkTo = value.linkTo;
+            return (
+              <div className="tag-wrapper-item">
+                <span
+                  key={`option-item-${index}-${option.label}`}
+                  className={`--tag tag-label ${
+                    value.index === index ? "--active" : ""
+                  }`}
+                  onClick={onClick(option)}
+                >
+                  {option.label}
+                </span>
+                {linkTo && value.index === index && (
+                  <ContextConsumer>
+                    {({ onRouteChange }) => (
+                      <span
+                        key={`option-item-${index}-${option.label}`}
+                        className={`--tag tag-link ${
+                          value.index === index ? "--active" : ""
+                        }`}
+                        onClick={() => {
+                          console.log(linkTo);
+                          onRouteChange(linkTo);
+                        }}
+                      >
+                        <TagLinkSvg width="10" color="#fff" />
+                      </span>
+                    )}
+                  </ContextConsumer>
+                )}
+              </div>
+            );
+          })}
         </div>
         <div className="__tags-wrapper --variant-select">
           <Select
             className={`${prefixClass("form-control")}`}
             classNamePrefix="react-select"
-            value={options[value.index]}
+            value={selectValue}
             options={options}
             onChange={({ value }) => onChange(value)}
           />
+          <span className="tags-variant-select-link">
+            <TagLinkSvg width="10" color="#0062ff" />
+            <ContextConsumer>
+              {({ onRouteChange }) => (
+                <a onClick={() => onRouteChange(selectLinkTo)}>
+                  {selectedLabel}
+                </a>
+              )}
+            </ContextConsumer>
+          </span>
         </div>
       </div>
     );

--- a/src/components/widgets/TagSelector/index.js
+++ b/src/components/widgets/TagSelector/index.js
@@ -2,7 +2,7 @@ import propTypes from "prop-types";
 import React from "react";
 import Select from "react-select";
 
-import { prefixClass } from "../../../utils";
+import { prefixClass, classNames } from "../../../utils";
 import { ContextConsumer } from "../../context";
 import { TagLinkSvg } from "../../Icons";
 
@@ -34,13 +34,24 @@ class TagSelector extends React.Component {
         <div className="__tags-wrapper --variant-tag">
           {options.map((option, index) => {
             const linkTo = option.value.linkTo;
+
+            const classTagLabel = classNames({
+              "--tag": true,
+              " tag-label": true,
+              "--active": value.index === index
+            });
+
+            const classTagLink = classNames({
+              "--tag": true,
+              "tag-link": true,
+              "--active": value.index === index
+            });
+
             return (
               <div className="tag-wrapper-item">
                 <span
                   key={`option-item-${index}-${option.label}`}
-                  className={`--tag tag-label ${
-                    value.index === index ? "--active" : ""
-                  }`}
+                  className={classTagLabel}
                   onClick={onClick(option)}
                 >
                   {option.label}
@@ -50,9 +61,7 @@ class TagSelector extends React.Component {
                     {({ onRouteChange }) => (
                       <span
                         key={`option-item-${index}-${option.label}`}
-                        className={`--tag tag-link ${
-                          value.index === index ? "--active" : ""
-                        }`}
+                        className={classTagLink}
                         onClick={() => {
                           onRouteChange(linkTo);
                         }}
@@ -75,7 +84,7 @@ class TagSelector extends React.Component {
             onChange={({ value }) => onChange(value)}
           />
           <span className="tags-variant-select-link">
-            <TagLinkSvg width="10" color="#0062ff" />
+            <TagLinkSvg width="10" color="#00c7d4" />
             <ContextConsumer>
               {({ onRouteChange }) => (
                 <a onClick={() => onRouteChange(selectLinkTo)}>

--- a/src/components/widgets/TagSelector/index.js
+++ b/src/components/widgets/TagSelector/index.js
@@ -54,7 +54,6 @@ class TagSelector extends React.Component {
                           value.index === index ? "--active" : ""
                         }`}
                         onClick={() => {
-                          console.log(linkTo);
                           onRouteChange(linkTo);
                         }}
                       >


### PR DESCRIPTION
### Reasons for making this change

Was not showing data types with oneOf/anyOf or nusted oneOf/anyOf. 
### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
