### PR TITLE
RJSF | Adding Ability to Mask Secret Keys in the Portal #1054

### DIFF
--- a/lib/components/Icons.js
+++ b/lib/components/Icons.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.TagLinkSvg = exports.JsonIcon = exports.RequiredInfoIcon = exports.ChevronIcon = exports.ArrowUpIcon = exports.ArrowDownIcon = exports.DeleteIcon = exports.CloseIcon = exports.PlusIcon = undefined;
+exports.EyeOpenSvg = exports.EyeOffSvg = exports.TagLinkSvg = exports.JsonIcon = exports.RequiredInfoIcon = exports.ChevronIcon = exports.ArrowUpIcon = exports.ArrowDownIcon = exports.DeleteIcon = exports.CloseIcon = exports.PlusIcon = undefined;
 
 var _react = require("react");
 
@@ -281,6 +281,86 @@ var TagLinkSvg = exports.TagLinkSvg = function TagLinkSvg(_ref9) {
           strokeLinecap: "round",
           strokeLinejoin: "round",
           strokeWidth: "1.2"
+        })
+      )
+    )
+  );
+};
+
+var EyeOffSvg = exports.EyeOffSvg = function EyeOffSvg() {
+  return _react2.default.createElement(
+    "svg",
+    {
+      xmlns: "http://www.w3.org/2000/svg",
+      width: "16.287",
+      height: "16.121",
+      viewBox: "0 0 18.287 18.121"
+    },
+    _react2.default.createElement(
+      "g",
+      { transform: "translate(-219.939 -6.939)" },
+      _react2.default.createElement("rect", { width: "16", height: "16", transform: "translate(220 7)", fill: "none" }),
+      _react2.default.createElement(
+        "g",
+        { transform: "translate(221 8)" },
+        _react2.default.createElement("path", {
+          d: "M13.663,14.5a7.493,7.493,0,0,1-4.44,1.551C3.99,16.047,1,10.024,1,10.024A13.866,13.866,0,0,1,4.783,5.551m2.871-1.37A6.771,6.771,0,0,1,9.223,4c5.233,0,8.223,6.024,8.223,6.024a13.936,13.936,0,0,1-1.615,2.4m-5.023-.806a2.237,2.237,0,0,1-3.814-.981,2.27,2.27,0,0,1,.644-2.212",
+          transform: "translate(-0.969 -2.023)",
+          fill: "none",
+          stroke: "#6b7e8f",
+          strokeLinecap: "round",
+          strokeLinejoin: "round",
+          strokeWidth: "1.5"
+        }),
+        _react2.default.createElement("line", {
+          x2: "16",
+          y2: "16",
+          transform: "translate(0 0)",
+          fill: "none",
+          stroke: "#6b7e8f",
+          strokeLinecap: "round",
+          strokeLinejoin: "round",
+          strokeWidth: "1.5"
+        })
+      )
+    )
+  );
+};
+
+var EyeOpenSvg = exports.EyeOpenSvg = function EyeOpenSvg() {
+  return _react2.default.createElement(
+    "svg",
+    {
+      xmlns: "http://www.w3.org/2000/svg",
+      width: "16.25",
+      height: "16",
+      viewBox: "0 0 18.25 18"
+    },
+    _react2.default.createElement(
+      "g",
+      { transform: "translate(-220 -7)" },
+      _react2.default.createElement("rect", { width: "16", height: "16", transform: "translate(220 7)", fill: "none" }),
+      _react2.default.createElement(
+        "g",
+        { transform: "translate(220 6)" },
+        _react2.default.createElement("path", {
+          d: "M1,10S4,4,9.25,4s8.25,6,8.25,6-3,6-8.25,6S1,10,1,10Z",
+          fill: "none",
+          stroke: "#6b7e8f",
+          strokeLinecap: "round",
+          strokeLinejoin: "round",
+          strokeWidth: "1.5"
+        }),
+        _react2.default.createElement("circle", {
+          cx: "3",
+          cy: "3",
+          r: "3",
+          transform: "translate(6.25 7)",
+          fill: "none",
+          stroke: "#6b7e8f",
+          strokeLinecap: "round",
+          strokeLinejoin: "round",
+          strokeWidth: "1.5"
         })
       )
     )

--- a/lib/components/widgets/BaseInput.js
+++ b/lib/components/widgets/BaseInput.js
@@ -137,20 +137,13 @@ var BaseInput = function (_Component) {
       var isSecret = schema.isSecret;
 
 
-      var typeText = options.inputType || type || "text";
+      var textType = options.inputType || type || "text";
 
-      var inputType = isSecret && isHidden ? "password" : typeText;
+      var inputType = isSecret && isHidden ? "password" : textType;
 
       var InputField = isSingleLine || isSecret ? "input" : "textarea";
 
       var isPassword = inputType === "password";
-      console.log("PROPS --->", {
-        inputProps: inputProps,
-        type: type,
-        typeText: typeText,
-        inputType: inputType,
-        isPassword: isPassword
-      });
 
       return _react2.default.createElement(
         _react2.default.Fragment,

--- a/lib/components/widgets/BaseInput.js
+++ b/lib/components/widgets/BaseInput.js
@@ -18,6 +18,8 @@ var _propTypes2 = _interopRequireDefault(_propTypes);
 
 var _utils = require("../../utils");
 
+var _Icons = require("../Icons");
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
@@ -37,7 +39,8 @@ var BaseInput = function (_Component) {
     var _this = _possibleConstructorReturn(this, (BaseInput.__proto__ || Object.getPrototypeOf(BaseInput)).call(this, props));
 
     _this.state = {
-      isSingleLine: true
+      isSingleLine: true,
+      isHidden: true
     };
 
     _this.onKeyDown = function (_ref) {
@@ -86,6 +89,14 @@ var BaseInput = function (_Component) {
       return _onChange(value.trimStart());
     };
 
+    _this.setPasswordVisibility = function () {
+      _this.setState(function (st) {
+        return _extends({}, st, {
+          isHidden: !st.isHidden
+        });
+      });
+    };
+
     _this.inputRef = _react2.default.createRef();
     return _this;
   }
@@ -117,32 +128,63 @@ var BaseInput = function (_Component) {
           formContext = _props.formContext,
           registry = _props.registry,
           onChange = _props.onChange,
-          inputProps = _objectWithoutProperties(_props, ["value", "readonly", "disabled", "autofocus", "onBlur", "onFocus", "options", "schema", "formContext", "registry", "onChange"]);
+          type = _props.type,
+          inputProps = _objectWithoutProperties(_props, ["value", "readonly", "disabled", "autofocus", "onBlur", "onFocus", "options", "schema", "formContext", "registry", "onChange", "type"]);
 
-      var isSingleLine = this.state.isSingleLine;
+      var _state = this.state,
+          isSingleLine = _state.isSingleLine,
+          isHidden = _state.isHidden;
+      var isSecret = schema.isSecret;
 
 
-      inputProps.type = options.inputType || inputProps.type || "text";
+      var typeText = options.inputType || type || "text";
 
-      var InputField = isSingleLine ? "input" : "textarea";
+      var inputType = isSecret && isHidden ? "password" : typeText;
 
-      return _react2.default.createElement(InputField, _extends({
-        ref: this.inputRef,
-        className: (0, _utils.prefixClass)("form-control"),
-        readOnly: readonly,
-        disabled: disabled,
-        autoFocus: autofocus,
-        value: value == null ? "" : value
-      }, inputProps, {
-        onChange: this.onChange,
-        onBlur: onBlur && function (event) {
-          return onBlur(inputProps.id, event.target.value);
-        },
-        onFocus: onFocus && function (event) {
-          return onFocus(inputProps.id, event.target.value);
-        },
-        onKeyDownCapture: this.onKeyDown
-      }));
+      var InputField = isSingleLine || isSecret ? "input" : "textarea";
+
+      var isPassword = inputType === "password";
+      console.log("PROPS --->", {
+        inputProps: inputProps,
+        type: type,
+        typeText: typeText,
+        inputType: inputType,
+        isPassword: isPassword
+      });
+
+      return _react2.default.createElement(
+        _react2.default.Fragment,
+        null,
+        _react2.default.createElement(InputField, _extends({
+          ref: this.inputRef,
+          className: (0, _utils.prefixClass)((0, _utils.classNames)({
+            "form-control": true,
+            "form-control-password": isSecret
+          })),
+          readOnly: readonly,
+          disabled: disabled,
+          autoFocus: autofocus,
+          value: value == null ? "" : value
+        }, inputProps, {
+          type: inputType,
+          onChange: this.onChange,
+          onBlur: onBlur && function (event) {
+            return onBlur(inputProps.id, event.target.value);
+          },
+          onFocus: onFocus && function (event) {
+            return onFocus(inputProps.id, event.target.value);
+          },
+          onKeyDownCapture: this.onKeyDown
+        })),
+        (isPassword || !isHidden) && _react2.default.createElement(
+          "div",
+          {
+            className: (0, _utils.prefixClass)("form-control-svg"),
+            onClick: this.setPasswordVisibility
+          },
+          isPassword ? _react2.default.createElement(_Icons.EyeOpenSvg, null) : _react2.default.createElement(_Icons.EyeOffSvg, null)
+        )
+      );
     }
   }]);
 

--- a/src/components/Icons.js
+++ b/src/components/Icons.js
@@ -232,3 +232,71 @@ export const TagLinkSvg = ({ width, color }) => {
     </svg>
   );
 };
+
+export const EyeOffSvg = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="18.287"
+    height="18.121"
+    viewBox="0 0 18.287 18.121"
+  >
+    <g transform="translate(-219.939 -6.939)">
+      <rect width="18" height="18" transform="translate(220 7)" fill="none" />
+      <g transform="translate(221 8)">
+        <path
+          d="M13.663,14.5a7.493,7.493,0,0,1-4.44,1.551C3.99,16.047,1,10.024,1,10.024A13.866,13.866,0,0,1,4.783,5.551m2.871-1.37A6.771,6.771,0,0,1,9.223,4c5.233,0,8.223,6.024,8.223,6.024a13.936,13.936,0,0,1-1.615,2.4m-5.023-.806a2.237,2.237,0,0,1-3.814-.981,2.27,2.27,0,0,1,.644-2.212"
+          transform="translate(-0.969 -2.023)"
+          fill="none"
+          stroke="#6b7e8f"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.5"
+        />
+        <line
+          x2="16"
+          y2="16"
+          transform="translate(0 0)"
+          fill="none"
+          stroke="#6b7e8f"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.5"
+        />
+      </g>
+    </g>
+  </svg>
+);
+
+export const EyeOpenSvg = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="18.25"
+    height="18"
+    viewBox="0 0 18.25 18"
+  >
+    <g transform="translate(-220 -7)">
+      <rect width="18" height="18" transform="translate(220 7)" fill="none" />
+      <g transform="translate(220 6)">
+        <path
+          d="M1,10S4,4,9.25,4s8.25,6,8.25,6-3,6-8.25,6S1,10,1,10Z"
+          fill="none"
+          stroke="#6b7e8f"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.5"
+        />
+        <circle
+          cx="3"
+          cy="3"
+          r="3"
+          transform="translate(6.25 7)"
+          fill="none"
+          stroke="#6b7e8f"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.5"
+        />
+      </g>
+    </g>
+  </svg>
+);

--- a/src/components/Icons.js
+++ b/src/components/Icons.js
@@ -248,9 +248,9 @@ export const EyeOffSvg = () => (
           transform="translate(-0.969 -2.023)"
           fill="none"
           stroke="#6b7e8f"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.5"
         />
         <line
           x2="16"
@@ -258,9 +258,9 @@ export const EyeOffSvg = () => (
           transform="translate(0 0)"
           fill="none"
           stroke="#6b7e8f"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.5"
         />
       </g>
     </g>
@@ -281,9 +281,9 @@ export const EyeOpenSvg = () => (
           d="M1,10S4,4,9.25,4s8.25,6,8.25,6-3,6-8.25,6S1,10,1,10Z"
           fill="none"
           stroke="#6b7e8f"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.5"
         />
         <circle
           cx="3"
@@ -292,9 +292,9 @@ export const EyeOpenSvg = () => (
           transform="translate(6.25 7)"
           fill="none"
           stroke="#6b7e8f"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.5"
         />
       </g>
     </g>

--- a/src/components/Icons.js
+++ b/src/components/Icons.js
@@ -236,12 +236,12 @@ export const TagLinkSvg = ({ width, color }) => {
 export const EyeOffSvg = () => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="18.287"
-    height="18.121"
+    width="16.287"
+    height="16.121"
     viewBox="0 0 18.287 18.121"
   >
     <g transform="translate(-219.939 -6.939)">
-      <rect width="18" height="18" transform="translate(220 7)" fill="none" />
+      <rect width="16" height="16" transform="translate(220 7)" fill="none" />
       <g transform="translate(221 8)">
         <path
           d="M13.663,14.5a7.493,7.493,0,0,1-4.44,1.551C3.99,16.047,1,10.024,1,10.024A13.866,13.866,0,0,1,4.783,5.551m2.871-1.37A6.771,6.771,0,0,1,9.223,4c5.233,0,8.223,6.024,8.223,6.024a13.936,13.936,0,0,1-1.615,2.4m-5.023-.806a2.237,2.237,0,0,1-3.814-.981,2.27,2.27,0,0,1,.644-2.212"
@@ -270,12 +270,12 @@ export const EyeOffSvg = () => (
 export const EyeOpenSvg = () => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="18.25"
-    height="18"
+    width="16.25"
+    height="16"
     viewBox="0 0 18.25 18"
   >
     <g transform="translate(-220 -7)">
-      <rect width="18" height="18" transform="translate(220 7)" fill="none" />
+      <rect width="16" height="16" transform="translate(220 7)" fill="none" />
       <g transform="translate(220 6)">
         <path
           d="M1,10S4,4,9.25,4s8.25,6,8.25,6-3,6-8.25,6S1,10,1,10Z"

--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -82,20 +82,20 @@ class BaseInput extends Component {
       formContext,
       registry,
       onChange,
+      type,
       ...inputProps
     } = this.props;
     const { isSingleLine, isHidden } = this.state;
 
-    const { isFormatPassword } = schema;
+    const { isSecret } = schema;
 
-    inputProps.type = options.inputType || inputProps.type || "text";
+    const textType = options.inputType || type || "text";
 
-    inputProps.type =
-      isFormatPassword && isHidden ? "password" : inputProps.type;
+    const inputType = isSecret && isHidden ? "password" : textType;
 
-    const InputField = isSingleLine || isFormatPassword ? "input" : "textarea";
+    const InputField = isSingleLine || isSecret ? "input" : "textarea";
 
-    const isPassword = inputProps.type === "password";
+    const isPassword = inputType === "password";
 
     return (
       <React.Fragment>
@@ -104,7 +104,7 @@ class BaseInput extends Component {
           className={pfx(
             classNames({
               "form-control": true,
-              "form-control-password": isFormatPassword
+              "form-control-password": isSecret
             })
           )}
           readOnly={readonly}
@@ -112,6 +112,7 @@ class BaseInput extends Component {
           autoFocus={autofocus}
           value={value == null ? "" : value}
           {...inputProps}
+          type={inputType}
           onChange={this.onChange}
           onBlur={
             onBlur && (event => onBlur(inputProps.id, event.target.value))

--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -1,10 +1,12 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { prefixClass as pfx } from "../../utils";
+import { classNames, prefixClass as pfx } from "../../utils";
+import { EyeOffSvg, EyeOpenSvg } from "../Icons";
 
 class BaseInput extends Component {
   state = {
-    isSingleLine: true
+    isSingleLine: true,
+    isHidden: true
   };
 
   constructor(props) {
@@ -58,6 +60,13 @@ class BaseInput extends Component {
     return _onChange(value.trimStart());
   };
 
+  setPasswordVisibility = () => {
+    this.setState(st => ({
+      ...st,
+      isHidden: !st.isHidden
+    }));
+  };
+
   render() {
     // Note: since React 15.2.0 we can't forward unknown element attributes, so we
     // exclude the "options" and "schema" ones here.
@@ -75,28 +84,52 @@ class BaseInput extends Component {
       onChange,
       ...inputProps
     } = this.props;
-    const { isSingleLine } = this.state;
+    const { isSingleLine, isHidden } = this.state;
+
+    const { isFormatPassword } = schema;
 
     inputProps.type = options.inputType || inputProps.type || "text";
 
-    const InputField = isSingleLine ? "input" : "textarea";
+    inputProps.type =
+      isFormatPassword && isHidden ? "password" : inputProps.type;
+
+    const InputField = isSingleLine || isFormatPassword ? "input" : "textarea";
+
+    const isPassword = inputProps.type === "password";
 
     return (
-      <InputField
-        ref={this.inputRef}
-        className={pfx("form-control")}
-        readOnly={readonly}
-        disabled={disabled}
-        autoFocus={autofocus}
-        value={value == null ? "" : value}
-        {...inputProps}
-        onChange={this.onChange}
-        onBlur={onBlur && (event => onBlur(inputProps.id, event.target.value))}
-        onFocus={
-          onFocus && (event => onFocus(inputProps.id, event.target.value))
-        }
-        onKeyDownCapture={this.onKeyDown}
-      />
+      <React.Fragment>
+        <InputField
+          ref={this.inputRef}
+          className={pfx(
+            classNames({
+              "form-control": true,
+              "form-control-password": isFormatPassword
+            })
+          )}
+          readOnly={readonly}
+          disabled={disabled}
+          autoFocus={autofocus}
+          value={value == null ? "" : value}
+          {...inputProps}
+          onChange={this.onChange}
+          onBlur={
+            onBlur && (event => onBlur(inputProps.id, event.target.value))
+          }
+          onFocus={
+            onFocus && (event => onFocus(inputProps.id, event.target.value))
+          }
+          onKeyDownCapture={this.onKeyDown}
+        />
+        {(isPassword || !isHidden) && (
+          <div
+            className={pfx("form-control-svg")}
+            onClick={this.setPasswordVisibility}
+          >
+            {isPassword ? <EyeOpenSvg /> : <EyeOffSvg />}
+          </div>
+        )}
+      </React.Fragment>
     );
   }
 }


### PR DESCRIPTION
### Reasons for making this change

At the moment, all the secret keys and passwords entered in the API Playground are readable. In order to protect them, DX Portal have masked these values.

If this is related to existing tickets, include links to them as well.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
