### PR TITLE
Icon misaligned in masking field

### DIFF
--- a/lib/components/widgets/BaseInput.js
+++ b/lib/components/widgets/BaseInput.js
@@ -146,8 +146,8 @@ var BaseInput = function (_Component) {
       var isPassword = inputType === "password";
 
       return _react2.default.createElement(
-        _react2.default.Fragment,
-        null,
+        "div",
+        { className: "rjsf-form-control-parent" },
         _react2.default.createElement(InputField, _extends({
           ref: this.inputRef,
           className: (0, _utils.prefixClass)((0, _utils.classNames)({

--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -98,7 +98,7 @@ class BaseInput extends Component {
     const isPassword = inputType === "password";
 
     return (
-      <React.Fragment>
+      <div className="rjsf-form-control-parent">
         <InputField
           ref={this.inputRef}
           className={pfx(
@@ -130,7 +130,7 @@ class BaseInput extends Component {
             {isPassword ? <EyeOpenSvg /> : <EyeOffSvg />}
           </div>
         )}
-      </React.Fragment>
+      </div>
     );
   }
 }


### PR DESCRIPTION
### Reasons for making this change

In case of screen width less than 1320 the masking icon misaligns of its normal position. That issue is fixed

If this is related to existing tickets, include links to them as well.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
